### PR TITLE
Add `AnnotationForge` to `Suggests`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ License: GPL (>=3)
 Encoding: UTF-8
 Depends: R (>= 3.6)  
 Imports: BiocManager, Biobase, utils, methods, RSQLite, devtools, dplR, stringr, graphics, stats, affxparser, data.table
-Suggests: siggenes, GEOquery, R.utils
+Suggests: siggenes, GEOquery, R.utils, AnnotationForge
 biocViews: DifferentialExpression, Microarray, OneChannel,
         ProprietaryPlatforms, DataImport
 LazyData: FALSE


### PR DESCRIPTION
Solves the following `R CMD check` [error](https://bioconductor.org/checkResults/3.18/bioc-LATEST/GCSscore/nebbiolo2-checksrc.html):
```
 ERROR
Errors in running code in vignettes:
when running code in ‘GCSscore.Rnw’
  ...
*This package will only be generated once for each chip-type*
*Or if probeFile version for the chip-type needs to be updated*
writing intermediary .probe_tab file to temporary directory
Importing the data.
Warning in packageDescription(thispkg) :
  no package 'AnnotationForge' was found

  When sourcing ‘GCSscore.R’:
Error: $ operator is invalid for atomic vectors
Execution halted
```



It seems `AnnotationForge` is a transitive dependency that must be explicitly declared for Bioc 3.18, because of _R_CHECK_SUGGESTS_ONLY_=true

See https://support.bioconductor.org/p/9153573/#9153581 for more details.
